### PR TITLE
fix doc for exposing methods from standard Rust traits

### DIFF
--- a/docs/manual/src/udl/interfaces.md
+++ b/docs/manual/src/udl/interfaces.md
@@ -173,7 +173,7 @@ generate special methods on the object.
 
 For example, consider the following example:
 ```
-[Traits=Debug]
+[Traits=(Debug)]
 interface TodoList {
     ...
 }


### PR DESCRIPTION
fix the issus #1933